### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 [![MCP Badge](https://lobehub.com/badge/mcp/mikusnuz-cws-mcp)](https://lobehub.com/mcp/mikusnuz-cws-mcp)
 
+[![cws-mcp MCP server](https://glama.ai/mcp/servers/mikusnuz/cws-mcp/badges/card.svg)](https://glama.ai/mcp/servers/mikusnuz/cws-mcp)
+
 MCP server for Chrome Web Store extension management. Upload, publish, and manage Chrome extensions directly from Claude Code or any MCP client.
 
 ## When to Use


### PR DESCRIPTION
This PR adds a badge for the [cws-mcp](https://glama.ai/mcp/servers/mikusnuz/cws-mcp) server listing in Glama MCP server directory.

[![cws-mcp MCP server](https://glama.ai/mcp/servers/mikusnuz/cws-mcp/badges/card.svg)](https://glama.ai/mcp/servers/mikusnuz/cws-mcp)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.